### PR TITLE
Refactor API and subscription tests

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -2,92 +2,16 @@ package deriv
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"log"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
 	"github.com/ksysoev/deriv-api/schema"
 )
-
-func newMockWSServer(cb func(ws *websocket.Conn)) *httptest.Server {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-			OriginPatterns: []string{"*"},
-		})
-		if err != nil {
-			return
-		}
-		defer c.CloseNow()
-
-		cb(c)
-
-		c.Close(websocket.StatusNormalClosure, "")
-	})
-
-	return httptest.NewServer(handler)
-}
-
-func echoHandler(ws *websocket.Conn) {
-	defer ws.CloseNow()
-
-	for {
-		msgType, reader, err := ws.Reader(context.TODO())
-		if err != nil {
-			return
-		}
-
-		if msgType != websocket.MessageText {
-			continue
-		}
-
-		buffer := bytes.NewBuffer(make([]byte, 0))
-		_, err = buffer.ReadFrom(reader)
-		if err != nil {
-			return
-		}
-
-		err = ws.Write(context.Background(), msgType, buffer.Bytes())
-		if err != nil {
-			return
-		}
-	}
-}
-
-func onMessageHanler(cb func(ws *websocket.Conn, msgType websocket.MessageType, msg []byte)) func(ws *websocket.Conn) {
-	return func(ws *websocket.Conn) {
-		var wg sync.WaitGroup
-		defer wg.Wait()
-
-		for {
-			msgType, reader, err := ws.Reader(context.TODO())
-			if err != nil {
-				return
-			}
-
-			buffer := bytes.NewBuffer(make([]byte, 0))
-			_, err = buffer.ReadFrom(reader)
-			if err != nil {
-				return
-			}
-
-			msg := buffer.Bytes()
-			wg.Add(1)
-			go func() {
-				cb(ws, msgType, msg)
-				wg.Done()
-			}()
-		}
-
-	}
-}
 
 func TestNewDerivAPI(t *testing.T) {
 	// Valid endpoint and origin

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/ksysoev/deriv-api
 
 go 1.20
 
-require (
-	github.com/coder/websocket v1.8.12
-	golang.org/x/net v0.24.0
-)
+require github.com/coder/websocket v1.8.12

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
-golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
-golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,83 @@
+package deriv
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/coder/websocket"
+)
+
+func newMockWSServer(cb func(ws *websocket.Conn)) *httptest.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			OriginPatterns: []string{"*"},
+		})
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+
+		cb(c)
+
+		c.Close(websocket.StatusNormalClosure, "")
+	})
+
+	return httptest.NewServer(handler)
+}
+
+func echoHandler(ws *websocket.Conn) {
+	defer ws.CloseNow()
+
+	for {
+		msgType, reader, err := ws.Reader(context.TODO())
+		if err != nil {
+			return
+		}
+
+		if msgType != websocket.MessageText {
+			continue
+		}
+
+		buffer := bytes.NewBuffer(make([]byte, 0))
+		_, err = buffer.ReadFrom(reader)
+		if err != nil {
+			return
+		}
+
+		err = ws.Write(context.Background(), msgType, buffer.Bytes())
+		if err != nil {
+			return
+		}
+	}
+}
+
+func onMessageHanler(cb func(ws *websocket.Conn, msgType websocket.MessageType, msg []byte)) func(ws *websocket.Conn) {
+	return func(ws *websocket.Conn) {
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		for {
+			msgType, reader, err := ws.Reader(context.TODO())
+			if err != nil {
+				return
+			}
+
+			buffer := bytes.NewBuffer(make([]byte, 0))
+			_, err = buffer.ReadFrom(reader)
+			if err != nil {
+				return
+			}
+
+			msg := buffer.Bytes()
+			wg.Add(1)
+			go func() {
+				cb(ws, msgType, msg)
+				wg.Done()
+			}()
+		}
+
+	}
+}


### PR DESCRIPTION
This pull request includes refactoring of the API tests to use the new WS library and refactoring of the subscription tests. It also moves the test helpers to a separate file.