### PR TITLE
chore: Update Go version to 1.21 in GitHub Actions workflow and go.mod file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.20.x", "1.21.x", "1.22.x"]
+        go-version: ["1.21.x", "1.22.x", "1.23.x"]
 
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ksysoev/deriv-api
 
-go 1.20
+go 1.21
 
 require github.com/coder/websocket v1.8.12


### PR DESCRIPTION
Update min Go version to 1.21 in GitHub Actions workflow and go.mod file