### PR TITLE
Update Go version and linting tool in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,23 +5,20 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.21.x", "1.22.x", "1.23.x"]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.24.x
 
       - name: Display Go version
         run: go version
       - name: Code Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.1
+          version: v1.64.8
       - name: Build
         run: go build -v .
       - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/deriv-api
 
-go 1.21
+go 1.24.1
 
 require github.com/coder/websocket v1.8.13
 


### PR DESCRIPTION
Upgrade the Go version to 1.24.x and update the linting tool to version 1.64.8 in the CI workflow.