### PR TITLE
Update golangci-lint version and refine linter settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Display Go version
         run: go version
       - name: Code Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.8
+          version: v2.0.1
       - name: Build
         run: go build -v .
       - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,8 @@
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-  errcheck:
-    check-type-assertions: true
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  govet:
-    enable:
-      - fieldalignment
-  nolintlint:
-    require-explanation: true
-    require-specific: true
-
+version: "2"
+run:
+  issues-exit-code: 1
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
@@ -30,35 +11,67 @@ linters:
     - exhaustive
     - goconst
     - gocritic
-    - gofmt
-    - goimports
     - gocyclo
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
-    - nolintlint
     - nakedret
+    - nolintlint
     - prealloc
     - predeclared
     - revive
     - staticcheck
-    - stylecheck
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
     - wsl
-
-issues:
-  exclude-rules:
-    - path: _test\.go$
-      linters:
-        - goconst
-
-run:
-  issues-exit-code: 1
+  settings:
+    errcheck:
+      check-type-assertions: true
+    exhaustive:
+      default-signifies-exhaustive: true
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    govet:
+      enable:
+        - fieldalignment
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - goconst
+        path: _test\.go$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,7 +64,7 @@ linters:
     paths:
       - third_party$
       - builtin$
-      - examples$
+      - examples
 formatters:
   enable:
     - gofmt
@@ -74,4 +74,4 @@ formatters:
     paths:
       - third_party$
       - builtin$
-      - examples$
+      - examples


### PR DESCRIPTION
Upgrade golangci-lint to version 2.0.1 and adjust linter settings for improved code quality and consistency.