### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Deriv API
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ksysoev/deriv-api/security/code-scanning/1](https://github.com/ksysoev/deriv-api/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will set explicit permissions for the `GITHUB_TOKEN`, ensuring it only has the privileges required for the actions in this workflow. In this case:
- `contents: read` is likely sufficient for reading repository contents, given the nature of the workflow.
- Additional permissions (e.g., `issues: write` or `pull-requests: write`) can be added if future modifications to the workflow require them.

The change is confined to the `.github/workflows/main.yml` file, and no additional dependencies or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
